### PR TITLE
fix(input): replace bind:value with explicit prop/event binding

### DIFF
--- a/app_crates/registry/src/ui/input.rs
+++ b/app_crates/registry/src/ui/input.rs
@@ -80,7 +80,8 @@ pub fn Input(
                 min=min
                 max=max
                 step=step
-                bind:value=signal
+                prop:value=move || signal.get()
+                on:input=move |ev| { signal.set(event_target_value(&ev)); }
                 node_ref=node_ref
             />
         }


### PR DESCRIPTION
Replaces `bind:value` with `prop:value` + `on:input` to fix an error in certain Leptos versions v0.8.17

error[E0599]: the method `bind` exists for struct `HtmlElement<Input, ..., ()>`, but its trait bounds were not satisfied
   --> src/components/ui/input.rs:67:25
    |
 67 |           Some(signal) => view! {
    |  _________________________^
 68 | |             <input
 69 | |                 data-name="Input"
 70 | |                 type=type_str
...   |
 85 | |             />
 86 | |         }
    | |_________^
    |
   ::: /Users/notnone/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/reactive_graph-0.2.13/src/wrappers.rs:452:5
    |
452 |       pub struct Signal<T, S = SyncStorage>
    |       ------------------------------------- doesn't satisfy `leptos::prelude::Signal<BoolOrT<_>>: IntoProperty`
    |
   ::: /Users/notnone/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tachys-0.2.14/src/html/element/mod.rs:37:1
    |
 37 |   pub struct HtmlElement<E, At, Ch> {
    |   --------------------------------- doesn't satisfy `_: BindAttribute<_, _, _>`
    |
    = note: the following trait bounds were not satisfied:
            `leptos::prelude::Signal<BoolOrT<_>>: IntoProperty`
            which is required by `leptos::html::HtmlElement<Input, (Class<std::string::String>, CustomAttr<&str, &str>, Attr<leptos::attr::Type, &str>, Attr<Placeholder, std::option::Option<std::string::String>>, Attr<leptos::attr::Name, std::option::Option<std::string::String>>, Attr<Id, std::option::Option<std::string::String>>, Attr<leptos::attr::Title, std::option::Option<std::string::String>>, Attr<leptos::attr::Disabled, bool>, Attr<Readonly, bool>, Attr<Required, bool>, Attr<Autofocus, bool>, Attr<Min, std::option::Option<std::string::String>>, Attr<Max, std::option::Option<std::string::String>>, Attr<leptos::attr::Step, std::option::Option<std::string::String>>), ()>: leptos::prelude::BindAttribute<_, _, _>`
            `&leptos::html::HtmlElement<Input, (Class<std::string::String>, CustomAttr<&str, &str>, Attr<leptos::attr::Type, &str>, Attr<Placeholder, std::option::Option<std::string::String>>, Attr<leptos::attr::Name, std::option::Option<std::string::String>>, Attr<Id, std::option::Option<std::string::String>>, Attr<leptos::attr::Title, std::option::Option<std::string::String>>, Attr<leptos::attr::Disabled, bool>, Attr<Readonly, bool>, Attr<Required, bool>, Attr<Autofocus, bool>, Attr<Min, std::option::Option<std::string::String>>, Attr<Max, std::option::Option<std::string::String>>, Attr<leptos::attr::Step, std::option::Option<std::string::String>>), ()>: AddAnyAttr`
            which is required by `&leptos::html::HtmlElement<Input, (Class<std::string::String>, CustomAttr<&str, &str>, Attr<leptos::attr::Type, &str>, Attr<Placeholder, std::option::Option<std::string::String>>, Attr<leptos::attr::Name, std::option::Option<std::string::String>>, Attr<Id, std::option::Option<std::string::String>>, Attr<leptos::attr::Title, std::option::Option<std::string::String>>, Attr<leptos::attr::Disabled, bool>, Attr<Readonly, bool>, Attr<Required, bool>, Attr<Autofocus, bool>, Attr<Min, std::option::Option<std::string::String>>, Attr<Max, std::option::Option<std::string::String>>, Attr<leptos::attr::Step, std::option::Option<std::string::String>>), ()>: leptos::prelude::BindAttribute<_, _, _>`
            `leptos::prelude::Signal<BoolOrT<_>>: IntoProperty`
            which is required by `&leptos::html::HtmlElement<Input, (Class<std::string::String>, CustomAttr<&str, &str>, Attr<leptos::attr::Type, &str>, Attr<Placeholder, std::option::Option<std::string::String>>, Attr<leptos::attr::Name, std::option::Option<std::string::String>>, Attr<Id, std::option::Option<std::string::String>>, Attr<leptos::attr::Title, std::option::Option<std::string::String>>, Attr<leptos::attr::Disabled, bool>, Attr<Readonly, bool>, Attr<Required, bool>, Attr<Autofocus, bool>, Attr<Min, std::option::Option<std::string::String>>, Attr<Max, std::option::Option<std::string::String>>, Attr<leptos::attr::Step, std::option::Option<std::string::String>>), ()>: leptos::prelude::BindAttribute<_, _, _>`
            `&mut leptos::html::HtmlElement<Input, (Class<std::string::String>, CustomAttr<&str, &str>, Attr<leptos::attr::Type, &str>, Attr<Placeholder, std::option::Option<std::string::String>>, Attr<leptos::attr::Name, std::option::Option<std::string::String>>, Attr<Id, std::option::Option<std::string::String>>, Attr<leptos::attr::Title, std::option::Option<std::string::String>>, Attr<leptos::attr::Disabled, bool>, Attr<Readonly, bool>, Attr<Required, bool>, Attr<Autofocus, bool>, Attr<Min, std::option::Option<std::string::String>>, Attr<Max, std::option::Option<std::string::String>>, Attr<leptos::attr::Step, std::option::Option<std::string::String>>), ()>: AddAnyAttr`
            which is required by `&mut leptos::html::HtmlElement<Input, (Class<std::string::String>, CustomAttr<&str, &str>, Attr<leptos::attr::Type, &str>, Attr<Placeholder, std::option::Option<std::string::String>>, Attr<leptos::attr::Name, std::option::Option<std::string::String>>, Attr<Id, std::option::Option<std::string::String>>, Attr<leptos::attr::Title, std::option::Option<std::string::String>>, Attr<leptos::attr::Disabled, bool>, Attr<Readonly, bool>, Attr<Required, bool>, Attr<Autofocus, bool>, Attr<Min, std::option::Option<std::string::String>>, Attr<Max, std::option::Option<std::string::String>>, Attr<leptos::attr::Step, std::option::Option<std::string::String>>), ()>: leptos::prelude::BindAttribute<_, _, _>`
            `leptos::prelude::Signal<BoolOrT<_>>: IntoProperty`
            which is required by `&mut leptos::html::HtmlElement<Input, (Class<std::string::String>, CustomAttr<&str, &str>, Attr<leptos::attr::Type, &str>, Attr<Placeholder, std::option::Option<std::string::String>>, Attr<leptos::attr::Name, std::option::Option<std::string::String>>, Attr<Id, std::option::Option<std::string::String>>, Attr<leptos::attr::Title, std::option::Option<std::string::String>>, Attr<leptos::attr::Disabled, bool>, Attr<Readonly, bool>, Attr<Required, bool>, Attr<Autofocus, bool>, Attr<Min, std::option::Option<std::string::String>>, Attr<Max, std::option::Option<std::string::String>>, Attr<leptos::attr::Step, std::option::Option<std::string::String>>), ()>: leptos::prelude::BindAttribute<_, _, _>`
    = note: the full name for the type has been written to '/Users/notnone/Desktop/WebAuthSystem/frontend/target/debug/deps/frontend-f3984d5efc5eea6e.long-type-4126408506728941292.txt'
    = note: consider using `--verbose` to print the full type name to the console
    = note: this error originates in the macro `view` (in Nightly builds, run with -Z macro-backtrace for more info)

For more information about this error, try `rustc --explain E0599`.
error: could not compile `frontend` (bin "frontend") due to 1 previous error