### PR TITLE
fix(docs): allow page scroll to chain past code blocks

### DIFF
--- a/app_crates/app_components/src/tree_view.rs
+++ b/app_crates/app_components/src/tree_view.rs
@@ -127,7 +127,7 @@ pub fn FileRendererHighlight(
                 class="peer"
                 checked=checked
                 on:change=move |_| {
-                    const HIGHLIGHT_CLASS: &str = "h-full max-h-[370px] overflow-y-auto overscroll-y-contain whitespace-pre-wrap p-4 [&_span]:text-xs rounded-md bg-muted";
+                    const HIGHLIGHT_CLASS: &str = "h-full max-h-[370px] overflow-y-auto whitespace-pre-wrap p-4 [&_span]:text-xs rounded-md bg-muted";
                     let highlighted_content = highlight_code(&content, language, Some(name));
                     let html = format!(
                         "<div><h3 class='font-semibold mb-2'>{name}</h3><pre class='{HIGHLIGHT_CLASS}' data-name='{SYNTECT_HIGHLIGHTER_CODE}'><code>{highlighted_content}</code></pre></div>",

--- a/crates/_markdown_crate/src/leptos/components/syntect_highlighter_code.rs
+++ b/crates/_markdown_crate/src/leptos/components/syntect_highlighter_code.rs
@@ -13,7 +13,7 @@ pub fn SyntectHighlighterCode(
 ) -> impl IntoView {
     let merged_class = tw_merge!(
         if show_scrollbar_on_hover { "scrollbar__on_hover" } else { "" },
-        "h-full max-h-[370px] overflow-y-auto overscroll-y-contain",
+        "h-full max-h-[370px] overflow-y-auto",
         "whitespace-pre-wrap p-4 [&_span]:text-xs rounded-md bg-muted",
         class
     );


### PR DESCRIPTION
## Summary

Resolves #15.

The `overscroll-y-contain` Tailwind class on the syntax-highlighted code block components was trapping scroll events. When the cursor was inside an overflowing code block, trackpad momentum got absorbed by the inner element instead of chaining up to the page, leaving the page unscrollable for several seconds (most noticeable in Chrome on macOS, where overscroll-behavior is strictly enforced; Safari is more lenient).

## Changes

Removes `overscroll-y-contain` from two read-only display components:

- `crates/_markdown_crate/src/leptos/components/syntect_highlighter_code.rs:16` — the `SyntectHighlighterCode` component used for inline code in component docs
- `app_crates/app_components/src/tree_view.rs:130` — the `FileRendererHighlight` highlighted file viewer in tree views

## Why these are safe to change

These two components are passive read-only displays of code. The user's natural intent when scrolling over them is to navigate the docs page, not the code block. Removing `overscroll-y-contain` restores the browser default of scroll chaining so the page continues scrolling once the code block reaches its boundary.

## What is intentionally NOT changed

`overscroll-y-contain` is left intact in:

- `app_crates/registry/src/ui/sheet.rs:101` — the Sheet modal component, where the trap is the desired behaviour for an interactive overlay
- `app/src/components/shared_sidenav_demos.rs:20` — sidenav demo wrapper, where the panel should scroll independently

## Test plan

- [x] Reproduced the bug in Chrome on macOS — confirmed cursor inside code block trapped scroll for ~5 seconds
- [x] Built locally with `cargo leptos watch`
- [x] Verified after fix: hovering inside the code block and scrolling now scrolls the page once the code block reaches its boundary
- [x] Verified Sheet component still locks scroll correctly when open
- [ ] Run e2e tests