### PR TITLE
docs: fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Rust/UI isn’t a component library you install as a crate. It’s a collection 
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=rust-ui/ui&type=Date)](https://star-history.com/#rust-ui/ui&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=rust-ui/ui&type=Date)](https://star-history.dera.page/#rust-ui/ui&Date)
 
 
 ## Ecosystem


### PR DESCRIPTION
The star history chart in the README is currently broken due to GitHub stargazer API restrictions. This change migrates the chart and its link to star-history.dera.page, which uses an alternative data source that requires no API token and keeps the same domain for both the API and the frontend. Fixing this is necessary to keep the project's star history visible.